### PR TITLE
Vista de Cambio de Contraseña

### DIFF
--- a/src/pages/profile/pages/change-password.page.tsx
+++ b/src/pages/profile/pages/change-password.page.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react';
+import clsx from 'clsx';
+import { Alert, KeenIcon } from '@/components';
+
+const ChangePasswordPage = () => {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  // Regex: Min 8 chars, 1 uppercase, 1 number
+  const passwordRegex = /^(?=.*[A-Z])(?=.*\d).{8,}$/;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+    setLoading(true);
+
+    if (!currentPassword.trim()) {
+      setError('La contraseña actual es requerida.');
+      setLoading(false);
+      return;
+    }
+    if (!passwordRegex.test(newPassword)) {
+      setError('La nueva contraseña debe tener al menos 8 caracteres, una mayúscula y un número.');
+      setLoading(false);
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError('Las contraseñas nuevas no coinciden.');
+      setLoading(false);
+      return;
+    }
+
+    // Simulación de éxito visual
+    setTimeout(() => {
+      setSuccess('Contraseña actualizada correctamente.');
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      setLoading(false);
+    }, 1000);
+  };
+
+  const togglePassword = (
+    e: React.MouseEvent<HTMLButtonElement>,
+    field: 'current' | 'new' | 'confirm'
+  ) => {
+    e.preventDefault();
+    if (field === 'current') setShowCurrentPassword(!showCurrentPassword);
+    if (field === 'new') setShowNewPassword(!showNewPassword);
+    if (field === 'confirm') setShowConfirmPassword(!showConfirmPassword);
+  };
+
+  return (
+    <div className="flex flex-col justify-center items-center min-h-screen w-screen">
+      <div className="card max-w-[450px] w-full">
+        <form className="card-body flex flex-col gap-5 p-10" onSubmit={handleSubmit} noValidate>
+          <h3 className="text-2xl font-semibold text-gray-900 text-center leading-none mb-2.5">
+            Cambiar Contraseña
+          </h3>
+
+          {error && <Alert variant="danger">{error}</Alert>}
+          {success && <Alert variant="success">{success}</Alert>}
+
+          <div className="flex flex-col gap-1">
+            <label className="form-label text-gray-900">Contraseña Actual</label>
+            <label className="input">
+              <input
+                type={showCurrentPassword ? 'text' : 'password'}
+                placeholder="Escribir contraseña actual"
+                autoComplete="off"
+                value={currentPassword}
+                onChange={e => setCurrentPassword(e.target.value)}
+                className="form-control"
+                required
+              />
+              <button className="btn btn-icon" onClick={e => togglePassword(e, 'current')}>
+                <KeenIcon
+                  icon="eye"
+                  className={clsx('text-gray-500', { hidden: showCurrentPassword })}
+                />
+                <KeenIcon
+                  icon="eye-slash"
+                  className={clsx('text-gray-500', { hidden: !showCurrentPassword })}
+                />
+              </button>
+            </label>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="form-label text-gray-900">Nueva Contraseña</label>
+            <label className="input">
+              <input
+                type={showNewPassword ? 'text' : 'password'}
+                placeholder="Escribir nueva contraseña"
+                autoComplete="off"
+                value={newPassword}
+                onChange={e => setNewPassword(e.target.value)}
+                className="form-control"
+                required
+              />
+              <button className="btn btn-icon" onClick={e => togglePassword(e, 'new')}>
+                <KeenIcon
+                  icon="eye"
+                  className={clsx('text-gray-500', { hidden: showNewPassword })}
+                />
+                <KeenIcon
+                  icon="eye-slash"
+                  className={clsx('text-gray-500', { hidden: !showNewPassword })}
+                />
+              </button>
+            </label>
+            <span className="text-2xs text-gray-600">Mínimo 8 caracteres, 1 mayúscula, 1 número</span>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="form-label text-gray-900">Confirmar Nueva Contraseña</label>
+            <label className="input">
+              <input
+                type={showConfirmPassword ? 'text' : 'password'}
+                placeholder="Confirmar nueva contraseña"
+                autoComplete="off"
+                value={confirmPassword}
+                onChange={e => setConfirmPassword(e.target.value)}
+                className="form-control"
+                required
+              />
+              <button className="btn btn-icon" onClick={e => togglePassword(e, 'confirm')}>
+                <KeenIcon
+                  icon="eye"
+                  className={clsx('text-gray-500', { hidden: showConfirmPassword })}
+                />
+                <KeenIcon
+                  icon="eye-slash"
+                  className={clsx('text-gray-500', { hidden: !showConfirmPassword })}
+                />
+              </button>
+            </label>
+          </div>
+
+          <button
+            type="submit"
+            className="btn btn-primary flex justify-center grow"
+            disabled={loading}
+          >
+            {loading ? 'Por favor espere...' : 'Cambiar Contraseña'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export { ChangePasswordPage };

--- a/src/pages/profile/pages/index.ts
+++ b/src/pages/profile/pages/index.ts
@@ -1,2 +1,2 @@
 export * from './profile-details';
-// export * from './default/ProfileDefaultPage';
+export * from './change-password.page';

--- a/src/routing/AppRoutingSetup.tsx
+++ b/src/routing/AppRoutingSetup.tsx
@@ -63,6 +63,7 @@ import {
   AuthenticationGetStartedPage
 } from '@/pages/authentication';
 import { ProfileDetailsPage } from '@/pages/profile/pages';
+import { ChangePasswordPage } from '@/pages/profile/pages';
 import { FinancialAccountOverviewPage } from '@/pages/financial-account/pages/financial-account-overview/financial-account-overview.component';
 import { SubjectPreselectionPage, SubjectSelectionPage } from '@/pages/processes/pages';
 import { AcademicSchedulePage, QualificationPage } from '@/pages/revision/pages';
@@ -73,6 +74,8 @@ import { SupportCenterPage } from '@/pages/help/pages/support-center/support-cen
 const AppRoutingSetup = (): ReactElement => {
   return (
     <Routes>
+      <Route path="/profile/change-password" element={<ChangePasswordPage />} />
+
       <Route element={<RequireAuth />}>
         <Route element={<AppLayout />}>
           {/* Dashboard Pages */}
@@ -80,8 +83,9 @@ const AppRoutingSetup = (): ReactElement => {
           <Route path="/dark-sidebar" element={<AppLayoutDarkSidebarPage />} />
 
           {/* Profile Pages */}
-          <Route path="/profile/details" element={<ProfileDetailsPage />} />
-
+          <Route path="/profile/details" element={<ProfileDetailsPage />}  /> 
+          {/* aqui va la ruta de change-password esta afuera para poder probar ya que la api de login para pruebas dejo de funcionar */}
+          
           {/* Financial Account Pages */}
 
           <Route path="/financial-account/overview" element={<FinancialAccountOverviewPage />} />


### PR DESCRIPTION
Ticket:

[AUTH-17] UI: Crear vista de "Cambio de Contraseña":
Qué: El componente visual (probablemente en la página de "Perfil").
Por qué: El formulario con "contraseña actual", "contraseña nueva" y "confirmar contraseña".

Esta UI es para lo siguiente: Escenario 2: Cambio contraseña (Desde el Perfil)
El usuario ya está logueado y quiere cambiar su clave por seguridad.

Creacion de la pantalla de cambio contraseña, tiene los campos contraseña actual, contraseña nueva y confirmar contraseña (Por el momento hasta que la api este lista al introducir campos simula que se hizo el cambio)

Para poder verla ir a la ruta intec/profile/change-password
